### PR TITLE
Calendar fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env*.local
 
 # vercel
@@ -35,4 +36,3 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
-.env

--- a/src/app/_components/DatePicker.tsx
+++ b/src/app/_components/DatePicker.tsx
@@ -51,6 +51,7 @@ export const DatePicker = ({ value: date, onChange }: DatePickerProps) => {
           selected={date}
           onSelect={onSelect}
           initialFocus
+          defaultMonth={date}
         />
       </PopoverContent>
     </Popover>

--- a/src/app/_components/TickerEOD.tsx
+++ b/src/app/_components/TickerEOD.tsx
@@ -5,7 +5,7 @@ import { DatePicker } from "./DatePicker";
 import type { Ticker } from "../_types/ticker";
 import type { TickerEOD as TickerEODType } from "../_types/ticker-eod";
 import { useEffect, useState } from "react";
-import { format, parse } from "date-fns";
+import { format, parse, subBusinessDays } from "date-fns";
 import { useSearchParams, usePathname, useRouter } from "next/navigation";
 import globals from "@/app/globals.module.css";
 import "./ticker-eod.css";
@@ -45,7 +45,7 @@ export const TickerEOD = ({ ticker, eod }: TickerEODInfoProps) => {
     if (dt) {
       setDate(parse(dt, "yyyy-MM-dd", new Date()));
     } else {
-      setDate(new Date());
+      setDate(subBusinessDays(new Date(), 1));
     }
   }, [searchParams]);
 

--- a/src/app/ticker/[symbol]/page.tsx
+++ b/src/app/ticker/[symbol]/page.tsx
@@ -3,7 +3,7 @@ import { TickerEOD } from "@/app/_components/TickerEOD";
 import { getTicker, getTickerEod, getTickerHistorical } from "@/api";
 import type { Ticker } from "@/app/_types/ticker";
 import { ArrowLeft } from "lucide-react";
-import { format, subDays } from "date-fns";
+import { format, subBusinessDays } from "date-fns";
 import TickerChart from "@/app/_components/TickerChart";
 import styles from "./styles.module.css";
 import globals from "@/app/globals.module.css";
@@ -18,10 +18,12 @@ function getDefaultParams({ params, searchParams }: PageProps) {
     searchParams: {
       h_date_from:
         searchParams?.h_date_from ??
-        format(subDays(new Date(), 30), "yyyy-MM-dd"),
-      h_date_to: searchParams?.h_date_to ?? format(new Date(), "yyyy-MM-dd"),
+        format(subBusinessDays(new Date(), 30), "yyyy-MM-dd"), // 30 days ago
+      h_date_to: searchParams?.h_date_to ?? format(new Date(), "yyyy-MM-dd"), // today
       h_pivot: searchParams?.h_pivot ?? "close",
-      eod_date: searchParams?.eod_date ?? format(new Date(), "yyyy-MM-dd"),
+      eod_date:
+        searchParams?.eod_date ??
+        format(subBusinessDays(new Date(), 1), "yyyy-MM-dd"), // yesterday
     },
   };
 }


### PR DESCRIPTION
### Fixes

- Setting the selected EOD date param to previous business day when no query param is provided
- Setting Calendar `defaultMonth` to the selected date so it shows a consistent month when `DatePicker` is opened

### Screens

<img width="822" alt="Screenshot 2024-03-12 at 1 35 15 p m" src="https://github.com/alexserver/thebroker/assets/694404/1b76f5e9-8218-45a5-b936-f36032875c1f">
